### PR TITLE
crashing with high memory consumption

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -3,6 +3,6 @@
 		"zkConnect": "192.168.33.10:2181"
     },
     "logging": {
-        "level" : "trace"
+        "level" : "debug"
     }
 }

--- a/lib/consumers.js
+++ b/lib/consumers.js
@@ -191,6 +191,7 @@ var get = function (group, id, callback) {
         }
 
         if (consumer.instance.paused) {
+            logger.info({ consumer: consumer.id }, 'lib/consumerManager : resuming consumer');
             consumer.instance.resume();
         }
 


### PR DESCRIPTION
* turn logging down to debug in development.json to stop node blowing up
* log the resume of a consumer to indicate that it's coming back from a pause