### PR TITLE
Support clients with base64 encode

### DIFF
--- a/controllers/testLatency.js
+++ b/controllers/testLatency.js
@@ -1,7 +1,7 @@
 var request = require('request-promise'),
     Promise = require('promise'),
     now = Date.now(),
-    baseUri = 'http://localhost:8085',
+    baseUri = process.argv.length > 2 ? process.argv[2] : "http://localhost:8085",
     topicUriSuffix = '/topics/test.' + now,
     topicUri = baseUri + topicUriSuffix,
     createConsumerUri = baseUri + '/consumers/test.' + now;
@@ -12,11 +12,21 @@ var consumerUri,
 request.put(topicUri)
     .then(function (r) {
         console.log('created topic ' + r);
-        return request.post(createConsumerUri);
+        var options = {
+            uri: createConsumerUri,
+            method: 'POST',
+            json: {
+                'value.encode': false
+            },
+            headers: {
+                'Content-Type': 'application/vnd.kafka.v1+json'
+            }
+        }
+        return request.post(options);
     })
     .then(function (r) {
-        console.log('created consumer ' + r);
-        consumerUri = JSON.parse(r).base_uri;
+        console.log('created consumer ', r);
+        consumerUri = r.base_uri;
         consumerTopicUri = consumerUri + topicUriSuffix;
         return request.get(consumerTopicUri);
     })


### PR DESCRIPTION
The confluent REST proxy required values to be encoded when submitted. The kafka-node library does this for us. This means that messages published using a library that dealt with the confluent proxy were being double encoded, which caused issues for messages >= 50% of kafka's message.max.bytes setting.

This PR resolves this by testing to see whether the message is base64 encoded before publishing it and decoding it. It also supports consumers specifying whether they want it encoded on the way out (true by default) so that consumers using the same library can continue to function.