### PR TITLE
allow large requests to be received by body parser

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -33,5 +33,9 @@
     },
     "health": {
         "okResponseText": "UP"
+    },
+    "http": {
+        "jsonContentType": "application/*+json",
+        "requestEntityLimit": "16mb"
     }
 }

--- a/server.js
+++ b/server.js
@@ -26,7 +26,7 @@ app.use(function(req, res, next) {
     next();
 });
 
-app.use(bodyParser.json({ type: 'application/*+json' }));
+app.use(bodyParser.json({ type: config.http.jsonContentType, limit: config.http.requestEntityLimit }));
 
 require('./controllers/topics')(app);
 require('./controllers/consumers')(app);


### PR DESCRIPTION
- stop express blowing up on large requests by setting the limit on bodyParser to 16mb
- make it configurable